### PR TITLE
Transparent Material Created and Applied to BP_Window

### DIFF
--- a/PoppingPals 5.3/Content/Assets/Materials/M_Transparent.uasset
+++ b/PoppingPals 5.3/Content/Assets/Materials/M_Transparent.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c3afbccc37a865a985219be9aef5a8deb648bb19a0f6f78dd427e07aca22a0e
+size 8815

--- a/PoppingPals 5.3/Content/Blueprints/Actors/BP_Window.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Actors/BP_Window.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b884f3e885f0af6cda068ae735a66c8149486f9ad6bcf770444b0bdcc0da812
-size 27671
+oid sha256:270539bdca06e3d5cce1e15b4707deac0f8bb6624a865f9f670c3a6e3821ae4c
+size 29235

--- a/PoppingPals 5.3/Content/Maps/Level1Map.umap
+++ b/PoppingPals 5.3/Content/Maps/Level1Map.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5a92558b7c33b3a5c5718cd1cf7ef6430fb4142b0dedfc7b11fe576c5ca0e9a3
+oid sha256:d57e2b408d72a655e448ddd2482abaf45d95e2f3ac06268d00de7bcfd1eaa543
 size 21614

--- a/PoppingPals 5.3/Content/Maps/MainMenuMap.umap
+++ b/PoppingPals 5.3/Content/Maps/MainMenuMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84210b1f12c874fdde6fecfa91d6c9b995ef96d1995d93a6d71672a31ca60b79
+oid sha256:e48f3a2ec797a19c7b5ecdffe0b605c35a92d24376e395322abfb1df30a74fc8
 size 61831


### PR DESCRIPTION
In preparation for future map changes, added a transparent / translucent material to the BP_Window. This will allow the user to see the background HDRI in full effect. Eventually will pair this with subtle camera movements to have more dynamic gameplay.