### PR TITLE
Setup Two Shot Power Up and Power Up Destruction

### DIFF
--- a/PoppingPals 5.3/.vscode/compileCommands_Default.json
+++ b/PoppingPals 5.3/.vscode/compileCommands_Default.json
@@ -262,5 +262,21 @@
             "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
             "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
         ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
+        ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.h",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
+        ]
     }
 ]

--- a/PoppingPals 5.3/.vscode/compileCommands_PoppingPals.json
+++ b/PoppingPals 5.3/.vscode/compileCommands_PoppingPals.json
@@ -262,5 +262,21 @@
             "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
             "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
         ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
+        ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.h",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
+        ]
     }
 ]

--- a/PoppingPals 5.3/Content/Assets_External/sA_PickupSet_1/Fx/NiagaraSystems/NS_Pickup_1.uasset
+++ b/PoppingPals 5.3/Content/Assets_External/sA_PickupSet_1/Fx/NiagaraSystems/NS_Pickup_1.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f56c973b917a5372475e1b38eed249da55bb17208b2f0547117fcaec5709e07d
-size 1254020
+oid sha256:9ee2eeacd935fc735fa480a81b8c6d0c844e3bc13c2d00231119105a635db06b
+size 762965

--- a/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_IncreaseShots.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_IncreaseShots.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:516f52a8195909e34cb5dda90028f7c55a1e3301fda188a3c8900b764d1edff6
-size 30718

--- a/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_TwoShots.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_TwoShots.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e69e427c5ecb7743b963aab5cad4efd4f75eda22bdc014fe47a70456fb194d
+size 34419

--- a/PoppingPals 5.3/Content/Maps/TestMap.umap
+++ b/PoppingPals 5.3/Content/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e51722fbdfde95ce35f5f59f9f09893dd3e4b6d96b0bf50539ed53d004734a3f
-size 26222
+oid sha256:e8dc11ad5983588c7a6f56b435ceebdaf1cfccf848a728c0e5e95b1a74d7d76e
+size 26762

--- a/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.cpp
@@ -84,7 +84,7 @@ void APopPal::SetupPlayerInputComponent(UInputComponent* PlayerInputComponent)
 
 void APopPal::Fire()
 {
-	if(projectileCount < 1) {
+	if(projectileCount < maxProjectiles) {
 		// Uncomment line below ONLY when aspect ratio is NOT constrained
 		// DrawDebugSphere(GetWorld(), projectileSpawnComp->GetComponentLocation(), 10.0f, 15, FColor::Red, false, 3.0f);
 		FVector spawnLoc = projectileSpawnComp->GetComponentLocation();

--- a/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
@@ -57,6 +57,9 @@ public:
 	UPROPERTY(VisibleAnywhere)
 	int projectileCount = 0;
 
+	UPROPERTY(VisibleAnywhere)
+	int maxProjectiles = 1;
+
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
 

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.h
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.h
@@ -19,6 +19,17 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
+	UPROPERTY(EditAnywhere, Category="Components")
+	class USphereComponent* powerUpColliderComp;
+
+	UPROPERTY(EditAnywhere, Category="Components")
+	class UStaticMeshComponent* powerUpMeshComp;
+
+	UPROPERTY(EditAnywhere, Category="Components")
+	class UNiagaraComponent* powerUpEffectComp;
+
+	class APopPal* popPal;
+
 	// Flashes power-up to signal player to pick it up before destruction
 	struct FTimerHandle powerUpFlashTimerHandle;
 
@@ -26,12 +37,6 @@ protected:
 	void FlashPowerUp();
 
 private:
-	UPROPERTY(EditAnywhere, Category="Components")
-	class UCapsuleComponent* powerUpColliderComp;
-
-	UPROPERTY(EditAnywhere, Category="Components")
-	class UNiagaraComponent* powerUpEffectComp;
-
 	UPROPERTY(EditAnywhere)
 	float linearDamp = 2.5f;
 

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
@@ -1,0 +1,58 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "IncreaseShotPowerUp.h"
+#include "Components/SphereComponent.h"
+#include "PoppingPals/Character/PopPal.h"
+
+// Sets default values
+AIncreaseShotPowerUp::AIncreaseShotPowerUp()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+// Called when the game starts or when spawned
+void AIncreaseShotPowerUp::BeginPlay()
+{
+	Super::BeginPlay();
+	
+	powerUpColliderComp->OnComponentBeginOverlap.AddDynamic(this, &AIncreaseShotPowerUp::OnOverlapBegin);
+}
+
+// Called every frame
+void AIncreaseShotPowerUp::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+void AIncreaseShotPowerUp::OnOverlapBegin(UPrimitiveComponent* overlappedComponent, AActor* otherActor, 
+UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHitResult& sweepResult)
+{
+
+	// Make sure otherActor exists and that it isn't itself
+	if(otherActor && otherActor != this) {
+		// If the overlap occurs with the player character, apply power up effect
+		if(otherActor == popPal) {
+			if(popPal->maxProjectiles < 2) {
+				popPal->maxProjectiles++;
+				GetWorldTimerManager().SetTimer(powerUpDurationHandle, this, &AIncreaseShotPowerUp::TwoShotPowerUp, 0.1f, false, powerUpDuration);
+				
+				// Hide powerup and disable collisions
+				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
+				SetActorHiddenInGame(true);
+				powerUpColliderComp->SetCollisionProfileName("NoCollision");
+			}
+		}
+	}
+}
+
+// Toggles the power ups visibility
+void AIncreaseShotPowerUp::TwoShotPowerUp() {
+	UE_LOG(LogTemp, Warning, TEXT("IncreaseShotPower Finished"));
+	popPal->maxProjectiles = 1;
+	GetWorldTimerManager().ClearTimer(powerUpDurationHandle);
+	Destroy();
+}

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.h
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.h
@@ -1,0 +1,40 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BasePowerUp.h"
+#include "IncreaseShotPowerUp.generated.h"
+
+UCLASS()
+class POPPINGPALS_API AIncreaseShotPowerUp : public ABasePowerUp
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	AIncreaseShotPowerUp();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+	// Allows the player to use the power up for a set amount of time
+	struct FTimerHandle powerUpDurationHandle;
+
+	// Toggles the power ups visibility
+	void TwoShotPowerUp();
+
+private:
+	UPROPERTY(EditAnywhere)
+	float powerUpDuration = 6.0f;
+
+	UFUNCTION()
+	void OnOverlapBegin(UPrimitiveComponent* overlappedComponent, AActor* otherActor, 
+	UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHitResult& sweepResult);
+
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+};


### PR DESCRIPTION
Created a IncreaseShotPowerUp script that subclasses BasePowerUp. It handles overlap collision with the player, so once the player comes into contact with it they are granted two projectiles to shoot for 6 seconds before they no longer have the power up. Whenever a power up is picked up the subclass of that power up will handle its destruction.