### PR TITLE
Added BP_Shield PowerUp; Fixed Overlapping PowerUp Bug

### DIFF
--- a/PoppingPals 5.3/.vscode/compileCommands_Default.json
+++ b/PoppingPals 5.3/.vscode/compileCommands_Default.json
@@ -294,5 +294,21 @@
             "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
             "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
         ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
+        ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_Default/PoppingPals.1.rsp"
+        ]
     }
 ]

--- a/PoppingPals 5.3/.vscode/compileCommands_PoppingPals.json
+++ b/PoppingPals 5.3/.vscode/compileCommands_PoppingPals.json
@@ -294,5 +294,21 @@
             "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
             "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
         ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
+        ]
+    },
+    {
+        "file": "/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h",
+        "directory": "/Users/Shared/Epic Games/UE_5.3/Engine/Source",
+        "arguments": [
+            "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++",
+            "@/Users/marco_capraro/Documents/GitHub/Popping-Pals/PoppingPals 5.3/.vscode/compileCommands_PoppingPals/PoppingPals.1.rsp"
+        ]
     }
 ]

--- a/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_Shield.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_Shield.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b8b8ac5edf4fc78deee992d44a51aa1a98692bf1d3c9bcd21958d9d1b5ee156
+size 31827

--- a/PoppingPals 5.3/Content/Maps/TestMap.umap
+++ b/PoppingPals 5.3/Content/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3cba8753f6340d352bd50a8fcdb72437948a24008d0f98f540a63c60a947188
-size 28293
+oid sha256:c6e0df6565f0af571d6170301b4becc27e6578df4f0bd49205e4968ceda007e5
+size 28213

--- a/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
@@ -71,6 +71,11 @@ public:
 
 	int32 jumpCount;
 
+	// Keep track of identical active powerups
+	int32 shotUpgradeCount = 0;
+	int32 jumpUpgradeCount = 0;
+	int32 shieldUpgradeCount = 0;
+
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
 

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.h
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.h
@@ -39,6 +39,8 @@ protected:
 	// Toggles the power ups visibility
 	void FlashPowerUp();
 
+	bool bPickedUp = false;
+
 private:
 	UPROPERTY(EditAnywhere)
 	float linearDamp = 2.5f;

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/DoubleJumpPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/DoubleJumpPowerUp.cpp
@@ -36,11 +36,17 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 	if(otherActor && otherActor != this) {
 		// If the overlap occurs with the player character, apply power up effect
 		if(otherActor == popPal) {
-			if(popPal->maxJumpCount < 2) {
-				popPal->maxJumpCount++;
+			if(!bPickedUp) {
+				bPickedUp = true;
+
+				// Increase num of allowed fire projectiles to 2 and regardless increment counter of two shot power ups picked up
+				if(popPal->maxJumpCount < 2) { popPal->maxJumpCount++; }
+				popPal->jumpUpgradeCount++;
+
+				UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
 				GetWorldTimerManager().SetTimer(doubleJumpHandle, this, &ADoubleJumpPowerUp::DoubleJump, 0.1f, false, powerUpDuration);
 				
-				// Hide powerup and disable collisions
+				// Hide powerup and prep for destruction
 				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
 				HandleDestruction();
 				SetActorHiddenInGame(true);
@@ -53,7 +59,12 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 // Toggles the power ups visibility
 void ADoubleJumpPowerUp::DoubleJump() {
 	UE_LOG(LogTemp, Warning, TEXT("DoubleJump Finished"));
-	popPal->maxJumpCount = 1;
+
+	// Handles overlapping effects of the same power up
+	if(popPal->jumpUpgradeCount <= 1) { popPal->maxJumpCount = 1; }
+	popPal->jumpUpgradeCount--;
+
+	UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
 	GetWorldTimerManager().ClearTimer(doubleJumpHandle);
 	Destroy();
 }

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
@@ -36,11 +36,17 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 	if(otherActor && otherActor != this) {
 		// If the overlap occurs with the player character, apply power up effect
 		if(otherActor == popPal) {
-			if(popPal->maxProjectiles < 2) {
-				popPal->maxProjectiles++;
+			if(!bPickedUp) {
+				bPickedUp = true;
+
+				// Increase num of allowed fire projectiles to 2 and regardless increment counter of two shot power ups picked up
+				if(popPal->maxProjectiles < 2) { popPal->maxProjectiles++; }
+				popPal->shotUpgradeCount++;
+
+				// UE_LOG(LogTemp, Warning, TEXT("Two Shots Picked Up = %i"), popPal->shotUpgradeCount);
 				GetWorldTimerManager().SetTimer(twoShotHandle, this, &AIncreaseShotPowerUp::TwoShot, 0.1f, false, powerUpDuration);
 				
-				// Hide powerup and disable collisions
+				// Hide powerup and prep for destruction
 				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
 				SetActorHiddenInGame(true);
 				HandleDestruction();
@@ -53,7 +59,12 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 // Toggles the power ups visibility
 void AIncreaseShotPowerUp::TwoShot() {
 	UE_LOG(LogTemp, Warning, TEXT("IncreaseShotPower Finished"));
-	popPal->maxProjectiles = 1;
+
+	// Handles overlapping effects of the same power up
+	if(popPal->shotUpgradeCount <= 1) { popPal->maxProjectiles = 1; }
+	popPal->shotUpgradeCount--;
+
+	// UE_LOG(LogTemp, Warning, TEXT("Two Shots Picked Up = %i"), popPal->shotUpgradeCount);
 	GetWorldTimerManager().ClearTimer(twoShotHandle);
 	Destroy();
 }

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
@@ -1,0 +1,64 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "ShieldPowerUp.h"
+#include "Components/SphereComponent.h"
+#include "PoppingPals/Character/PopPal.h"
+
+// Sets default values
+AShieldPowerUp::AShieldPowerUp()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+// Called when the game starts or when spawned
+void AShieldPowerUp::BeginPlay()
+{
+	Super::BeginPlay();
+	
+	powerUpColliderComp->OnComponentBeginOverlap.AddDynamic(this, &AShieldPowerUp::OnOverlapBegin);
+}
+
+// Called every frame
+void AShieldPowerUp::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+
+void AShieldPowerUp::OnOverlapBegin(UPrimitiveComponent* overlappedComponent, AActor* otherActor, 
+UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHitResult& sweepResult)
+{
+
+	// Make sure otherActor exists and that it isn't itself
+	if(otherActor && otherActor != this) {
+		// If the overlap occurs with the player character, apply power up effect
+		if(otherActor == popPal) {
+			if(!bPickedUp) {
+				bPickedUp = true;
+
+				GetWorldTimerManager().SetTimer(shieldHandle, this, &AShieldPowerUp::Shield, 0.1f, false, powerUpDuration);
+				
+				// Hide powerup and prep for destruction
+				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
+				SetActorHiddenInGame(true);
+				HandleDestruction();
+				powerUpColliderComp->SetCollisionProfileName("NoCollision");
+			}
+		}
+	}
+}
+
+// Toggles the power ups visibility
+void AShieldPowerUp::Shield() {
+	UE_LOG(LogTemp, Warning, TEXT("Shield Finished"));
+	
+	GetWorldTimerManager().ClearTimer(shieldHandle);
+	Destroy();
+}
+
+void AShieldPowerUp::HandleDestruction() {
+	Super::HandleDestruction();
+}

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h
@@ -1,0 +1,41 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "BasePowerUp.h"
+#include "ShieldPowerUp.generated.h"
+
+UCLASS()
+class POPPINGPALS_API AShieldPowerUp : public ABasePowerUp
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	AShieldPowerUp();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+	// Allows the player to use the power up for a set amount of time
+	struct FTimerHandle shieldHandle;
+
+	// Toggles the power ups visibility
+	void Shield();
+
+private:
+	UPROPERTY(EditAnywhere)
+	float powerUpDuration = 6.0f;
+
+	UFUNCTION()
+	void OnOverlapBegin(UPrimitiveComponent* overlappedComponent, AActor* otherActor, 
+	UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHitResult& sweepResult);
+
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+	void HandleDestruction();
+
+};


### PR DESCRIPTION
Created Shield script that subclasses BasePowerUp, but power up effect yet to be implemented. Created temporary Blueprint for Shield script to create a placeable actor in the scene to test the power up. Fixed overlapping effects of picking up the same power up. Previously, when picking up the same power up in a small time span the effect would be cleared once the first duration was over, now the power up will persist until the last one's duration is finished.