### PR TITLE
Refactored Destruction Handling of Powerups

### DIFF
--- a/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_Shield.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Actors/PowerUps/BP_Shield.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b8b8ac5edf4fc78deee992d44a51aa1a98692bf1d3c9bcd21958d9d1b5ee156
-size 31827
+oid sha256:b03d146bf70b94b6ffa0f81e6fbfff229b7a3d98aa582912fafaebb95cb2f633
+size 31882

--- a/PoppingPals 5.3/Content/Blueprints/Particles/P_Trail_Basic.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Particles/P_Trail_Basic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e7c202c69d3c7bfd097e3dbeb2abf7e74bc3db832970f51f8f44fac68f8232d
+oid sha256:dfe219c33075a5f15f16ad403c6207bcc13506acadf088b845752b6b8430e0a6
 size 336288

--- a/PoppingPals 5.3/Content/Maps/TestMap.umap
+++ b/PoppingPals 5.3/Content/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6e0df6565f0af571d6170301b4becc27e6578df4f0bd49205e4968ceda007e5
-size 28213
+oid sha256:337109d12c42c8479f260ccfca6429fac9056e4aaf1c174fb0d77a4f79589930
+size 28214

--- a/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
@@ -44,6 +44,8 @@ void UHealthComponent::DamageTaken(AActor* damagedActor, float damage, const UDa
 {
 	// Make sure to avoid nonsensical values
 	if(damage <= 0.0f) return;
+
+	// If player is damagedActor and shield, don't take damage, destroy shield (decrement shieldUpgradeCount)
 	health -= damage;
 
 	// Debug Character Health

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.cpp
@@ -102,6 +102,11 @@ void ABasePowerUp::FlashPowerUp()
 }
 
 void ABasePowerUp::HandleDestruction() {
+	// Clear flash timer, hide actor, and disable collisions
+	GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
+	SetActorHiddenInGame(true);
+	powerUpColliderComp->SetCollisionProfileName("NoCollision");
+
 	// Setup pickup effect and sound
 	if(pickUpEffect) {
 		UNiagaraComponent* niagaraComp = UNiagaraFunctionLibrary::SpawnSystemAtLocation(this, pickUpEffect, GetActorLocation(), GetActorRotation());

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/DoubleJumpPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/DoubleJumpPowerUp.cpp
@@ -43,14 +43,11 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 				if(popPal->maxJumpCount < 2) { popPal->maxJumpCount++; }
 				popPal->jumpUpgradeCount++;
 
-				UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
+				// UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
 				GetWorldTimerManager().SetTimer(doubleJumpHandle, this, &ADoubleJumpPowerUp::DoubleJump, 0.1f, false, powerUpDuration);
 				
-				// Hide powerup and prep for destruction
-				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
+				// Prepare powerup for destruction
 				HandleDestruction();
-				SetActorHiddenInGame(true);
-				powerUpColliderComp->SetCollisionProfileName("NoCollision");
 			}
 		}
 	}
@@ -64,7 +61,7 @@ void ADoubleJumpPowerUp::DoubleJump() {
 	if(popPal->jumpUpgradeCount <= 1) { popPal->maxJumpCount = 1; }
 	popPal->jumpUpgradeCount--;
 
-	UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
+	// UE_LOG(LogTemp, Warning, TEXT("Double Jumps Picked Up = %i"), popPal->jumpUpgradeCount);
 	GetWorldTimerManager().ClearTimer(doubleJumpHandle);
 	Destroy();
 }

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/IncreaseShotPowerUp.cpp
@@ -47,10 +47,7 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 				GetWorldTimerManager().SetTimer(twoShotHandle, this, &AIncreaseShotPowerUp::TwoShot, 0.1f, false, powerUpDuration);
 				
 				// Hide powerup and prep for destruction
-				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
-				SetActorHiddenInGame(true);
 				HandleDestruction();
-				powerUpColliderComp->SetCollisionProfileName("NoCollision");
 			}
 		}
 	}

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
@@ -38,25 +38,19 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 		if(otherActor == popPal) {
 			if(!bPickedUp) {
 				bPickedUp = true;
+				popPal->shieldUpgradeCount++;
 
-				GetWorldTimerManager().SetTimer(shieldHandle, this, &AShieldPowerUp::Shield, 0.1f, false, powerUpDuration);
+				// If the shield power up isn't active yet apply effect
+				if(popPal->shieldUpgradeCount <= 1) {
+					// Create an actor sphere around player, with transparent material
+
+				}
 				
-				// Hide powerup and prep for destruction
-				GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
-				SetActorHiddenInGame(true);
+				// Prepare powerup for destruction
 				HandleDestruction();
-				powerUpColliderComp->SetCollisionProfileName("NoCollision");
 			}
 		}
 	}
-}
-
-// Toggles the power ups visibility
-void AShieldPowerUp::Shield() {
-	UE_LOG(LogTemp, Warning, TEXT("Shield Finished"));
-	
-	GetWorldTimerManager().ClearTimer(shieldHandle);
-	Destroy();
 }
 
 void AShieldPowerUp::HandleDestruction() {

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.h
@@ -19,12 +19,6 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
-	// Allows the player to use the power up for a set amount of time
-	struct FTimerHandle shieldHandle;
-
-	// Toggles the power ups visibility
-	void Shield();
-
 private:
 	UPROPERTY(EditAnywhere)
 	float powerUpDuration = 6.0f;


### PR DESCRIPTION
Previously subclasses handled a portion of the objects destruction when they are not picked up by the player. Now reduced code complexity by moving that logic into a single block in HandleDestruction() of the BasePowerUp parent class.