### PR TITLE
Added Functionality to ShieldPowerUp

### DIFF
--- a/PoppingPals 5.3/Content/Blueprints/Character/BP_RobotPal.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Character/BP_RobotPal.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04418d0cae87750f3b390dc7fced0b17d93df6e0e4502f54df89161403a36a50
-size 93787
+oid sha256:d7416e8757bd8ed27d43e6d82d588f8b7f3f182906994aa7d03aa080b13bdc7c
+size 56826

--- a/PoppingPals 5.3/Content/Maps/TestMap.umap
+++ b/PoppingPals 5.3/Content/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:337109d12c42c8479f260ccfca6429fac9056e4aaf1c174fb0d77a4f79589930
-size 28214
+oid sha256:d72ca7d34e41a21f0640adec42b578f9efb78f2d2780e4333e0a402786909833
+size 30104

--- a/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.cpp
@@ -57,13 +57,15 @@ void APopPal::BeginPlay()
 	maxJumpCount = 1;
 	jumpCount = 0;
 
+	// Store reference of shield mesh for visibility toggling in other files
+	shieldComp = Cast<UStaticMeshComponent>(GetComponentByClass(UStaticMeshComponent::StaticClass())); 
+
 	APlayerController* popPalController = GetWorld()->GetFirstPlayerController();
 	if(popPalController) {
 		if(UEnhancedInputLocalPlayerSubsystem* subSystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(popPalController->GetLocalPlayer())) {
 			subSystem->AddMappingContext(popPalContext, 0);
 		}
 	}
-	
 }
 
 // Called every frame

--- a/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/PopPal.h
@@ -74,7 +74,12 @@ public:
 	// Keep track of identical active powerups
 	int32 shotUpgradeCount = 0;
 	int32 jumpUpgradeCount = 0;
-	int32 shieldUpgradeCount = 0;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	bool bShieldVisible = false;
+
+	// Reference to shield component
+	class UStaticMeshComponent* shieldComp;
 
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;

--- a/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
@@ -6,6 +6,8 @@
 #include "Kismet/GameplayStatics.h"
 #include "PoppingPals/GameMode/PoppingPalsGameModeBase.h"
 #include "PoppingPals/Character/PopPal.h"
+#include "NiagaraFunctionLibrary.h"
+#include "NiagaraComponent.h"
 
 // Sets default values for this component's properties
 UHealthComponent::UHealthComponent()
@@ -46,14 +48,44 @@ void UHealthComponent::DamageTaken(AActor* damagedActor, float damage, const UDa
 	if(damage <= 0.0f) return;
 
 	// If player is damagedActor and shield, don't take damage, destroy shield (decrement shieldUpgradeCount)
-	health -= damage;
-
-	// Debug Character Health
 	if(damagedActor == popPal) {
-		UE_LOG(LogTemp, Warning, TEXT("Health = %f"), health);
+		if(popPal->shieldComp) {
+			// In the event there is an active shield power up, prevent damage, but destroy shield effect
+			if(popPal->bShieldVisible) {
+				// Hide Shield, Play Effect, Return
+				popPal->bShieldVisible = false;
+				popPal->shieldComp->ToggleVisibility();
+				if(destroyEffect) {
+					UNiagaraComponent* niagaraComp = UNiagaraFunctionLibrary::SpawnSystemAtLocation(this, destroyEffect, popPal->GetActorLocation(), popPal->GetActorRotation());
+					// Set the shape of the particle effect on spawn
+					niagaraComp->SetNiagaraVariableFloat(FString("Sphere Radius"), 30);
+				}
+
+				return;
+				
+			} else {
+				// Sets a looping timer to toggle visibility of players mesh to signify they took damage
+				GetWorld()->GetTimerManager().SetTimer(playerFlashHandle, this, &UHealthComponent::PlayerFlash, 0.1f, true);
+			}
+		}
 	}
 
+	// Decrease health as long as player doesn't have an active shield
+	health -= damage;
+	
+	// UE_LOG(LogTemp, Warning, TEXT("Health = %f"), health);
 	if(health <= 0.0f && poppingPalGameMode) {
 		poppingPalGameMode->ActorDied(damagedActor);
+	}
+}
+
+void UHealthComponent::PlayerFlash()
+{
+	popPal->characterMesh->ToggleVisibility();
+	if(flashLoopCounter > 6) {
+		flashLoopCounter = 0;
+		GetWorld()->GetTimerManager().ClearTimer(playerFlashHandle);
+	} else {
+		flashLoopCounter++;
 	}
 }

--- a/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.h
+++ b/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.h
@@ -28,6 +28,17 @@ private:
 	class APopPal* popPal;
 	class APoppingPalsGameModeBase* poppingPalGameMode;
 
+	UPROPERTY(EditAnywhere, Category="VFX")
+	class UNiagaraSystem* destroyEffect;
+
+	// Allows the player to flash when hit
+	struct FTimerHandle playerFlashHandle;
+
+	// Flash functionality
+	void PlayerFlash();
+
+	int16 flashLoopCounter = 0;
+
 	UFUNCTION()
 	void DamageTaken(AActor* damagedActor, float damage, const UDamageType* damageType, class AController* instigator, AActor* damageCauser);
 

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/BasePowerUp.cpp
@@ -105,6 +105,7 @@ void ABasePowerUp::HandleDestruction() {
 	// Clear flash timer, hide actor, and disable collisions
 	GetWorldTimerManager().ClearTimer(powerUpFlashTimerHandle);
 	SetActorHiddenInGame(true);
+	powerUpColliderComp->SetSimulatePhysics(false);
 	powerUpColliderComp->SetCollisionProfileName("NoCollision");
 
 	// Setup pickup effect and sound

--- a/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/PowerUps/ShieldPowerUp.cpp
@@ -38,16 +38,18 @@ UPrimitiveComponent* otherComp, int32 otherBodyIndex, bool bFromSweep, const FHi
 		if(otherActor == popPal) {
 			if(!bPickedUp) {
 				bPickedUp = true;
-				popPal->shieldUpgradeCount++;
 
-				// If the shield power up isn't active yet apply effect
-				if(popPal->shieldUpgradeCount <= 1) {
-					// Create an actor sphere around player, with transparent material
-
+				if(popPal->shieldComp) {
+					// If the shield power up isn't active yet apply effect
+					if(!popPal->bShieldVisible) {
+						popPal->bShieldVisible = true;
+						popPal->shieldComp->ToggleVisibility();
+					}
 				}
 				
-				// Prepare powerup for destruction
+				// Destroy powerup drop
 				HandleDestruction();
+				Destroy();
 			}
 		}
 	}


### PR DESCRIPTION
Now when a user picks up a shield power up, it will create a "bubble" shield around the player. That shield will remain in effect until the player is hit by an enemy, at which point the bubble will be destroyed and no damage will be taken by the player.