### PR TITLE
Updated Player Hit Notification (Flash)

### DIFF
--- a/PoppingPals 5.3/Content/Blueprints/Character/BP_RobotPal.uasset
+++ b/PoppingPals 5.3/Content/Blueprints/Character/BP_RobotPal.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f90d00963383af2aa1c2b58576c04c12e1357b0e3873dfc8af51177f519d2c5
-size 74689
+oid sha256:d5b548ead2fd19493e2e54bc061749c1daa0360fae4511bf0bc946117176868a
+size 74159

--- a/PoppingPals 5.3/Source/PoppingPals/Character/Projectile.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/Projectile.cpp
@@ -53,6 +53,7 @@ void AProjectile::OnHit(UPrimitiveComponent* hitComp, AActor* otherActor, UPrimi
 		// Handle Popping (Destruction) of Ball Enemies
 		if(otherActor->IsA(ABaseEnemy::StaticClass())) {
 			UGameplayStatics::ApplyDamage(otherActor, damage, nullptr, this, damageTypeClass);
+			// Get PowerUpComponent and call powerUpDropRoll() -> determines whether or not a power up drops after splitting an enemy
 		}
 
 		// UGameplayStatics::ApplyDamage(otherActor, damage, myOwnerInstigator, this, damageTypeClass);

--- a/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/CustomComponents/HealthComponent.cpp
@@ -4,6 +4,8 @@
 #include "HealthComponent.h"
 #include "GameFramework/Actor.h"
 #include "Kismet/GameplayStatics.h"
+#include "Components/SceneComponent.h"
+#include "Components/StaticMeshComponent.h"
 #include "PoppingPals/GameMode/PoppingPalsGameModeBase.h"
 #include "PoppingPals/Character/PopPal.h"
 #include "NiagaraFunctionLibrary.h"
@@ -92,7 +94,18 @@ void UHealthComponent::IncreasePlayerHealth() {
 
 void UHealthComponent::PlayerFlash()
 {
+	// Toggle Visibility of the Children Components (UStaticMesh), Except Shield
+	TArray<USceneComponent*> childrenMesh;
+	popPal->characterMesh->GetChildrenComponents(false, childrenMesh);
+	for(USceneComponent* comp : childrenMesh) {
+		if(comp->IsA(UStaticMeshComponent::StaticClass()) && comp->GetName() != TEXT("Bubble Shield")) {
+			comp->ToggleVisibility();
+		}
+	}
+
+	// Toggle Player Character Mesh Visibility to Simulate "Taken Damage"
 	popPal->characterMesh->ToggleVisibility();
+
 	if(flashLoopCounter > 6) {
 		flashLoopCounter = 0;
 		GetWorld()->GetTimerManager().ClearTimer(playerFlashHandle);


### PR DESCRIPTION
Previously the visibility of the children static mesh components attached to the BP_RobotPal's character mesh wouldn't be toggled since the function call doesn't propagate to the children of the character mesh. Now, the visibility of all children static mesh's attached to the character mesh, EXCEPT for the shield will toggle as expected.