### PR TITLE
Started Implementing a Loot Table

### DIFF
--- a/PoppingPals 5.3/Content/Maps/TestMap.umap
+++ b/PoppingPals 5.3/Content/Maps/TestMap.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17c3dce1f0e53b0f1ab96794f06cb4f2bda30ede1a8d8ae60b7238974c78fb12
+oid sha256:051410b17cdefad3649df8bbf60e5f907164b7135bd9296f82c1c91b76f333f6
 size 32774

--- a/PoppingPals 5.3/Source/PoppingPals/Character/Projectile.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/Character/Projectile.cpp
@@ -53,7 +53,6 @@ void AProjectile::OnHit(UPrimitiveComponent* hitComp, AActor* otherActor, UPrimi
 		// Handle Popping (Destruction) of Ball Enemies
 		if(otherActor->IsA(ABaseEnemy::StaticClass())) {
 			UGameplayStatics::ApplyDamage(otherActor, damage, nullptr, this, damageTypeClass);
-			// Get PowerUpComponent and call powerUpDropRoll() -> determines whether or not a power up drops after splitting an enemy
 		}
 
 		// UGameplayStatics::ApplyDamage(otherActor, damage, myOwnerInstigator, this, damageTypeClass);

--- a/PoppingPals 5.3/Source/PoppingPals/GameMode/PoppingPalsGameModeBase.cpp
+++ b/PoppingPals 5.3/Source/PoppingPals/GameMode/PoppingPalsGameModeBase.cpp
@@ -3,6 +3,7 @@
 
 #include "PoppingPalsGameModeBase.h"
 #include "Kismet/GameplayStatics.h"
+#include "Kismet/KismetMathLibrary.h"
 #include "PoppingPals/Character/PopPal.h"
 #include "PoppingPals/Enemies/BaseEnemy.h"
 #include "PoppingPals/Enemies/EnemyT4.h"
@@ -42,6 +43,14 @@ void APoppingPalsGameModeBase::ActorDied(AActor* deadActor)
             enemy->HandleDestruction();
         }
 
+        // Create a loot table for all power ups that can drop, including a null item (no drop)
+        // each item in the loot table has associated class and weight
+
+        // Create a function that calculates the total probability
+        // Sums the weight of all items in the loot table (must = 100)
+        // Generate a random number (1,100) and then compare that to the range of each weight
+        // If in the range of an item, spawn it, or if its the null item do nothing
+        
 
         if(targetBallEnemies == 0) {
             // If player destroys all ball enemies in a level, player wins the game (bool bWonGame = true)
@@ -87,4 +96,41 @@ int32 APoppingPalsGameModeBase::GetEnemyBallCount()
 
     // Iterate through array and determine total count
     return totalCount;
+}
+
+
+void APoppingPalsGameModeBase::RandomDropRate(TArray<FItem> itemTable, TSubclassOf<AActor> &itemDrop, bool &dropRateEqual100)
+{
+    // Declare temporary integer array for storing all "Drop Rates"
+    TArray <int32> DropRateArray;
+    int32 EqualTo100 = 0;
+ 
+    // Add input array drop rates to temporary array while summing the values to create a range "max" for each Loot Item
+    for (int x = 0; x < itemTable.Num(); ++x){
+        if (x == 0){
+            DropRateArray.Add(FMath::Abs(itemTable[x].dropRate));
+        } else {
+            DropRateArray.Add(FMath::Abs(itemTable[x].dropRate) + (DropRateArray[x-1]));
+        }
+    }
+ 
+    // Ensure all "Drop Rates" sum to EXACTLY 100
+ 
+    if (DropRateArray.Last() == 100){   
+        // Generate a random number
+        int32 DropIndex = UKismetMathLibrary::RandomIntegerInRange(1, 100);      
+ 
+        // Start with the lowest range "max value" and keep moving up until random int <= max of range
+        for (int x = 0; x < DropRateArray.Num(); ++x){
+            if (DropIndex <= DropRateArray[x]){
+                itemDrop = itemTable[x].itemClass;
+                break;
+            }
+        }
+        dropRateEqual100 = true;
+    // If drop rates do NOT sum to exactly 100 return a false boolean and a null drop item
+    } else {
+        itemDrop = nullptr;
+        dropRateEqual100 = false;
+    }
 }

--- a/PoppingPals 5.3/Source/PoppingPals/GameMode/PoppingPalsGameModeBase.h
+++ b/PoppingPals 5.3/Source/PoppingPals/GameMode/PoppingPalsGameModeBase.h
@@ -6,9 +6,22 @@
 #include "GameFramework/GameModeBase.h"
 #include "PoppingPalsGameModeBase.generated.h"
 
-/**
- * 
- */
+// Custom struct that ties an object class to an integer to determine a drop rate
+USTRUCT()
+struct FItem
+{
+	GENERATED_USTRUCT_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Category="Loot Struct")
+	TSubclassOf<AActor> itemClass;
+
+	UPROPERTY(EditAnywhere, Category="Loot Struct")
+	int32 dropRate;
+	
+};
+
+
 UCLASS()
 class POPPINGPALS_API APoppingPalsGameModeBase : public AGameModeBase
 {
@@ -17,6 +30,9 @@ class POPPINGPALS_API APoppingPalsGameModeBase : public AGameModeBase
 public:
 	virtual void BeginPlay() override;
 	void ActorDied(AActor* deadActor);
+
+	UFUNCTION(Category="Loot Table")
+	static void RandomDropRate(TArray<FItem> itemTable, TSubclassOf<AActor> &itemDrop, bool &dropRateEqual100);
 
 protected:
 	UFUNCTION(BlueprintImplementableEvent)


### PR DESCRIPTION
The loot table will keep track of a list of power ups and their respective drop rates. In addition, it will calculate the random drop rate percentage to determine if a power up is spawned after an enemy death.